### PR TITLE
Fix lease details form bug

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -44,7 +44,7 @@ docs_service = build('docs', 'v1', credentials=creds)
 
 def copy_lease_template(beat_name, artist_name):
     
-    copy_title = f'{beat_name} - Lease Agreement (Non-Exclusive) - {artist_name}'
+    copy_title = f'{artist_name} - {beat_name} - Licence (Non-Exclusive)'
     
     body = {
         'name': copy_title,
@@ -141,7 +141,7 @@ def create_lease(producers_legal_name, producers_professional_name, artists_lega
                             "matchCase": "False",
                             "text": "[[lease date]]" # Text to replace
                         },
-                        "replaceText": str(datetime.today().strftime("%d/%m/%Y, %H:%M:%S")) # Text to replace it with
+                        "replaceText": str(datetime.today().strftime("%d/%m/%Y, %H:%M")) # Text to replace it with
                     }
                 },
             ]

--- a/templates/lease_form.html
+++ b/templates/lease_form.html
@@ -19,7 +19,7 @@
         <input type="text" name="artists_professional_name" required="required">
     </div>
 
-    <input type="submit" value="Get files">
+    <input type="submit" value="Get files" onClick="this.form.submit(); this.disabled=true; this.value='Submitting…'; ">
 </form>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #5
- Removed errors section, and just incorporate the payment failed error into the capture order function.
- Split the lease form and capture order into two separate functions. Lease form redirects to capture order (which creates the lease doc and captures the payment.)
EDIT: All that was needed was a bit of JS in the input button tag.
- Updated send_confirmation_email to only run when method is 'get' (so that it doesn't run every time a file is downloaded on the receipt page.)